### PR TITLE
updates Structurizr to 1.15.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,7 +7,7 @@ ARG INSTALL_ZSH="true"
 ARG UPGRADE_PACKAGES="false"
 
 # Install needed packages and setup non-root user. Use a separate RUN statement to add your own dependencies.
-ARG STRUCTURIZR_VERSION=1.8.0
+ARG STRUCTURIZR_VERSION=1.15.0
 ARG USERNAME=vscode
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID


### PR DESCRIPTION
Bumps Structurizr version to 1.15.0 by updating the STRUCTURIZR_VERSION arg in the Dockerfile. I was able to build and open the remote container in VS Code. Tested validate, push, pull, list, and export commands. I'm using a free Structurizr cloud account which doesn't support lock and unlock. Let me know if there are any other tests I should perform. Thanks!